### PR TITLE
New Feature: repo url should be optional when creating an app for vetting

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -6,7 +6,7 @@ class App < ActiveRecord::Base
   has_many :iterations, :through => :engagements
 
   validates_presence_of :name, :description, :org_id, :status
-  validates_presence_of :repository_url, unless: :pending?
+  validates_presence_of :repository_url, unless: :pending? || :inVettingStatus?
 
   enum status: [:dead, :development, :in_use, :in_use_and_wants_improvement, :inactive_but_wants_improvement, :pending, 
     :vetting_pending, :on_hold, :staff_approved,:customer_informed, :customer_confirmation_received, :declined_by_staff, 

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -6,7 +6,7 @@ class App < ActiveRecord::Base
   has_many :iterations, :through => :engagements
 
   validates_presence_of :name, :description, :org_id, :status
-  validates_presence_of :repository_url, unless: :pending? || :inVettingStatus?
+  validates_presence_of :repository_url, unless: :repoUrlOptional?
 
   enum status: [:dead, :development, :in_use, :in_use_and_wants_improvement, :inactive_but_wants_improvement, :pending, 
     :vetting_pending, :on_hold, :staff_approved,:customer_informed, :customer_confirmation_received, :declined_by_staff, 
@@ -40,11 +40,14 @@ class App < ActiveRecord::Base
   end
 
   def inVettingStatus?
-    VETTING_STATUSES.include? self.status
+    @@VETTING_STATUSES.include? status.to_sym
   end
 
   def inDeploymentStatus?
-    DEPLOYMENT_STATUSES.include? self.status
+    @@DEPLOYMENT_STATUSES.include? status.to_sym
   end
 
+  def repoUrlOptional?
+    pending? || inVettingStatus?
+  end
 end

--- a/features/apps_controller.feature
+++ b/features/apps_controller.feature
@@ -82,6 +82,7 @@ Scenario: Login to github to create a new app in non-pending deployment status
   When I fill in "App Name" with "Fake app"
   When I fill in "App Description" with "Fake app description "
   When I fill in "Deployment Url" with "http://fakeapp.com"
+  When I fill in "Repository Url" with "http://fakerepo.com"
   And I press "Create App"
   Then I should be on the apps page
   And I should see "App was successfully created."

--- a/features/apps_controller.feature
+++ b/features/apps_controller.feature
@@ -45,6 +45,26 @@ Scenario: Login to github to create a new app
   Then I should be on the apps page
   And I should see "App was successfully created."
 
+Scenario: Login to github to create a new app in vetting status
+  #Story ID: #152298585
+  Given I am not logged in
+  And I am on the apps page
+  And I follow "New App"
+  And I am on the login page
+  And I follow "Log in with GitHub"
+  And I am on the new_app page
+  And I select "Vetting pending" from "Status"
+  And I press "Create App"
+  And I should see "2 errors prohibited App from being saved:"
+  And I should see "App Name can't be blank"
+  And I should see "App Description can't be blank"
+  When I fill in "App Name" with "Fake app"
+  When I fill in "App Description" with "Fake app description "
+  When I fill in "Deployment Url" with "http://fakeapp.com"
+  And I press "Create App"
+  Then I should be on the apps page
+  And I should see "App was successfully created."
+
 Scenario: Login to github to edit an existing app successfully
   #Story ID: #152298585
   Given I am not logged in

--- a/features/apps_controller.feature
+++ b/features/apps_controller.feature
@@ -46,7 +46,7 @@ Scenario: Login to github to create a new app
   And I should see "App was successfully created."
 
 Scenario: Login to github to create a new app in vetting status
-  #Story ID: #152298585
+  #Story ID: #165265798
   Given I am not logged in
   And I am on the apps page
   And I follow "New App"

--- a/features/apps_controller.feature
+++ b/features/apps_controller.feature
@@ -75,7 +75,7 @@ Scenario: Login to github to create a new app in non-pending deployment status
   And I am on the new_app page
   And I select "Development" from "Status"
   And I press "Create App"
-  And I should see "2 errors prohibited App from being saved:"
+  And I should see "3 errors prohibited App from being saved:"
   And I should see "App Name can't be blank"
   And I should see "App Description can't be blank"
   And I should see "Repository url can't be blank"

--- a/features/apps_controller.feature
+++ b/features/apps_controller.feature
@@ -65,6 +65,27 @@ Scenario: Login to github to create a new app in vetting status
   Then I should be on the apps page
   And I should see "App was successfully created."
 
+Scenario: Login to github to create a new app in non-pending deployment status
+  #Story ID: #165265798
+  Given I am not logged in
+  And I am on the apps page
+  And I follow "New App"
+  And I am on the login page
+  And I follow "Log in with GitHub"
+  And I am on the new_app page
+  And I select "Development" from "Status"
+  And I press "Create App"
+  And I should see "2 errors prohibited App from being saved:"
+  And I should see "App Name can't be blank"
+  And I should see "App Description can't be blank"
+  And I should see "Repository url can't be blank"
+  When I fill in "App Name" with "Fake app"
+  When I fill in "App Description" with "Fake app description "
+  When I fill in "Deployment Url" with "http://fakeapp.com"
+  And I press "Create App"
+  Then I should be on the apps page
+  And I should see "App was successfully created."
+
 Scenario: Login to github to edit an existing app successfully
   #Story ID: #152298585
   Given I am not logged in


### PR DESCRIPTION
add an app during the vetting stage shouldn't require repo URL.