### PR TITLE
New feature: add hyperlink to org name on index page

### DIFF
--- a/app/views/apps/index.html.haml
+++ b/app/views/apps/index.html.haml
@@ -43,7 +43,8 @@
         %td
           = app.id
           = link_to app.name, app
-        %td= app.org.name
+        %td
+          = link_to app.org.name, app.org
         %td
           = app.description
           %br


### PR DESCRIPTION
- The organization column has hyperlink values instead of plain text so that the user can directly navigate to the organization details page